### PR TITLE
Change line types and colours

### DIFF
--- a/R/plot_trajectory.R
+++ b/R/plot_trajectory.R
@@ -177,12 +177,12 @@ value_span <- function(data) {
 }
 
 line_colours <- function(data) {
-  linecolours <- c("black", "black", "gray", "grey46", "black")
+  linecolours <- c("black", "black", "grey46", "black", "grey46")
   c(scenario_lines(data)$colour, rev(linecolours[1:lines_n(data)]))
 }
 
 line_types <- function(data) {
-  linetypes <- c("solid", "dashed", "solid", "solid", "twodash")
+  linetypes <- c("solid", "dashed", "solid", "twodash", "longdash")
   c(rep("solid", nrow(scenario_lines(data))), rev(linetypes[1:lines_n(data)]))
 }
 


### PR DESCRIPTION
Closes #389 

In this PR I change the colours of benchmark lines to improve their visibility. Resulting chart (on fake data):

![image](https://user-images.githubusercontent.com/26434113/137163876-8ae50085-615f-46e1-a6f4-e405d24ea557.png)

FYI @Antoine-Lalechere 