### PR TITLE
Remove reudndant information that is implicit

### DIFF
--- a/R/to_title.R
+++ b/R/to_title.R
@@ -1,4 +1,4 @@
-#' Functions to replicate labels produced with `qplot_*()` functions
+#' Replicate labels produced with `qplot_*()` functions
 #'
 #' * `to_title()` converts labels like [qplot_emission_intensity()].
 #' * `format_metric()` converts labels like [qplot_trajectory()].

--- a/man/to_title.Rd
+++ b/man/to_title.Rd
@@ -5,7 +5,7 @@
 \alias{format_metric}
 \alias{recode_metric_techmix}
 \alias{spell_out_technology}
-\title{Functions to replicate labels produced with \verb{qplot_*()} functions}
+\title{Replicate labels produced with \verb{qplot_*()} functions}
 \usage{
 to_title(x)
 


### PR DESCRIPTION
Other functions don't start with "Function to ..."﻿
