### PR TITLE
Replace all `ald` references with `abcd`

### DIFF
--- a/data-raw/update_market_share_csv.R
+++ b/data-raw/update_market_share_csv.R
@@ -1,10 +1,10 @@
 library(dplyr)
 
 out <- r2dii.data::loanbook_demo %>%
-  r2dii.match::match_name(r2dii.data::ald_demo) %>%
+  r2dii.match::match_name(r2dii.data::abcd_demo) %>%
   r2dii.match::prioritize() %>%
   r2dii.analysis::target_market_share(
-    r2dii.data::ald_demo,
+    r2dii.data::abcd_demo,
     r2dii.data::scenario_demo_2020,
     r2dii.data::region_isos_demo
   ) %>%

--- a/data-raw/update_sda_csv.R
+++ b/data-raw/update_sda_csv.R
@@ -2,11 +2,11 @@ library(dplyr)
 
 out <- r2dii.match::match_name(
   r2dii.data::loanbook_demo,
-  r2dii.data::ald_demo
+  r2dii.data::abcd_demo
 ) %>%
   r2dii.match::prioritize() %>%
   r2dii.analysis::target_sda(
-    ald = r2dii.data::ald_demo,
+    abcd = r2dii.data::abcd_demo,
     co2_intensity_scenario = r2dii.data::co2_intensity_scenario_demo,
     region_isos = r2dii.data::region_isos_demo
   )

--- a/tests/testthat/test-market_share.R
+++ b/tests/testthat/test-market_share.R
@@ -41,12 +41,12 @@ test_that("outputs like r2dii.analysis::target_market_share()", {
 
   # The style `namespace::fun()` highlights this is an integration test
   lbk <- r2dii.data::loanbook_demo[1:10, ]
-  ald <- r2dii.data::ald_demo[795:800, ]
-  matched <- r2dii.match::prioritize(r2dii.match::match_name(lbk, ald))
+  abcd <- r2dii.data::abcd_demo[795:800, ]
+  matched <- r2dii.match::prioritize(r2dii.match::match_name(lbk, abcd))
 
   scenario <- r2dii.data::scenario_demo_2020
   region <- r2dii.data::region_isos_demo
-  exp_df <- r2dii.analysis::target_market_share(matched, ald, scenario, region)
+  exp_df <- r2dii.analysis::target_market_share(matched, abcd, scenario, region)
   expected <- vapply(sort_df(exp_df), typeof, character(1))
 
   act_df <- market_share

--- a/tests/testthat/test-sda.R
+++ b/tests/testthat/test-sda.R
@@ -18,14 +18,14 @@ test_that("outputs like r2dii.analysis::target_sda()", {
 
   # Pick small data for speed. "package::f()" is to emphasize integration
   loanbook <- r2dii.data::loanbook_demo
-  ald <- filter(r2dii.data::ald_demo, !is.na(.data$emission_factor))
+  abcd <- filter(r2dii.data::abcd_demo, !is.na(.data$emission_factor))
   scenario <- r2dii.data::co2_intensity_scenario_demo
   region_isos <- r2dii.data::region_isos_demo
 
-  expected <- r2dii.match::match_name(loanbook, ald) %>%
+  expected <- r2dii.match::match_name(loanbook, abcd) %>%
     r2dii.match::prioritize() %>%
     r2dii.analysis::target_sda(
-      ald,
+      abcd,
       co2_intensity_scenario = scenario,
       region_isos = region_isos
     ) %>%

--- a/vignettes/r2dii-plot.Rmd
+++ b/vignettes/r2dii-plot.Rmd
@@ -31,7 +31,7 @@ r2dii.data package.
 
 ```{r}
 loanbook <- loanbook_demo
-ald <- ald_demo
+abcd <- abcd_demo
 scenario <- co2_intensity_scenario_demo
 region <- region_isos_demo
 ```
@@ -41,7 +41,7 @@ r2dii.analysis.
 
 ```{r}
 matched <- loanbook %>%
-  match_name(ald) %>%
+  match_name(abcd) %>%
   prioritize() # Remember to validate matches (see `?prioritize`)
 ```
 
@@ -79,7 +79,7 @@ Use `qplot_emission_intensity()` with `sda`-like data.
 
 ```{r}
 data <- matched %>%
-  target_sda(ald, co2_intensity_scenario = scenario, region_isos = region) %>%
+  target_sda(abcd, co2_intensity_scenario = scenario, region_isos = region) %>%
   filter(
     sector == "cement",
     region == "global",
@@ -93,7 +93,7 @@ Use `qplot_trajectory()` with `market_share`-like data.
 
 ```{r}
 data <- matched %>%
-  target_market_share(ald, scenario = scenario_demo_2020, region_isos = region) %>%
+  target_market_share(abcd, scenario = scenario_demo_2020, region_isos = region) %>%
   filter(
     technology == "renewablescap", 
     region == "global", 
@@ -107,7 +107,7 @@ Use `qplot_techmix()` with `market_share`-like data.
 
 ```{r}
 data <- matched %>%
-  target_market_share(ald, scenario = scenario_demo_2020, region_isos = region) %>%
+  target_market_share(abcd, scenario = scenario_demo_2020, region_isos = region) %>%
   filter(
     sector == "power",
     region == "global",
@@ -139,7 +139,7 @@ The basic output of the function looks rather unappealing.
 
 ```{r}
 data <- matched %>%
-  target_sda(ald, co2_intensity_scenario = scenario, region_isos = region) %>%
+  target_sda(abcd, co2_intensity_scenario = scenario, region_isos = region) %>%
   filter(
     sector == "cement",
     region == "global", 
@@ -155,7 +155,7 @@ You can use parameters of `plot_emission_intensity()` to replicate features of
 
 ```{r}
 data <- matched %>%
-  target_sda(ald, co2_intensity_scenario = scenario, region_isos = region) %>%
+  target_sda(abcd, co2_intensity_scenario = scenario, region_isos = region) %>%
   filter(
     sector == "cement",
     region == "global", 
@@ -218,7 +218,7 @@ title and axis labels.
 
 ```{r}
 data <- matched %>%
-  target_market_share(ald, scenario = scenario_demo_2020, region_isos = region) %>%
+  target_market_share(abcd, scenario = scenario_demo_2020, region_isos = region) %>%
   filter(
     technology == "renewablescap",
     region == "global",


### PR DESCRIPTION
I have replace all references to `ald` and `ald_demo` with the new values `abcd` and `abcd_demo`. This avoids deprecation warnings from other packages. 

Relates to: 
https://github.com/RMI-PACTA/r2dii.data/pull/280
https://github.com/RMI-PACTA/r2dii.match/pull/400
https://github.com/RMI-PACTA/r2dii.analysis/pull/407