### PR TITLE
use full demo data in test to avoid problem using new demo data

### DIFF
--- a/tests/testthat/_snaps/plot_techmix.md
+++ b/tests/testthat/_snaps/plot_techmix.md
@@ -45,7 +45,7 @@
 
     Code
       invisible(plot_techmix(mydata))
-    Message <rlang_message>
+    Message
       The `technology_share` values are plotted for extreme years.
       Do you want to plot different years? E.g. filter mydata with:`subset(mydata, year %in% c(2020, 2030))`.
 

--- a/tests/testthat/test-market_share.R
+++ b/tests/testthat/test-market_share.R
@@ -40,8 +40,8 @@ test_that("outputs like r2dii.analysis::target_market_share()", {
   sort_df <- function(data) data[sort(names(data))]
 
   # The style `namespace::fun()` highlights this is an integration test
-  lbk <- r2dii.data::loanbook_demo[1:10, ]
-  abcd <- r2dii.data::abcd_demo[795:800, ]
+  lbk <- r2dii.data::loanbook_demo
+  abcd <- r2dii.data::abcd_demo
   matched <- r2dii.match::prioritize(r2dii.match::match_name(lbk, abcd))
 
   scenario <- r2dii.data::scenario_demo_2020


### PR DESCRIPTION
Presumably, these lines restricted the number of lines of demo data being used to improve performance (?), but this makes the test very sensitive to legitimate changes in the demo datasets, e.g. if the explicitly specified rows no longer contain matching rows. An incoming update to the demo datasets in https://github.com/RMI-PACTA/r2dii.data/pull/316 will make this test fail, but this PR will allow it to pass by removing the explicit filtering of rows. https://github.com/RMI-PACTA/r2dii.plot/blob/b4b87e8a3fe0a07367b1de15ef097250507f258e/tests/testthat/test-market_share.R#L43-L44

EDIT: also had to update a snapshot to take into account a newly added (by rlang developers, unrelated to this PR) `<rlang_message>` tag so that tests here pass

EDIT: tests still fail because apparently existing release version of `r2dii.data::abcd_demo` `year` column is type `<double>` instead of `<integer>` even though the script to create it explicitly sets it to `<integer>`. Tempted to just let that slide here because the new version of `r2dii.data::abcd_demo` will be properly typed and that test will then pass.