### PR TITLE
Remove current scenario bar from techmix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # r2dii.plot (development version)
 
+* techmix plot does not show the start year scenario bar anymore. (#513)
+
 # r2dii.plot 0.3.1
 
 * Gains new datasets: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # r2dii.plot (development version)
 
+## New features
+
 * techmix plot does not show the start year scenario bar anymore. (#513)
 
 # r2dii.plot 0.3.1

--- a/R/plot_techmix.R
+++ b/R/plot_techmix.R
@@ -136,7 +136,8 @@ prep_techmix <- function(data,
     ))
   }
   out <- out %>%
-    filter(.data$year %in% c(start_year, future_year))
+    filter(.data$year %in% c(start_year, future_year)) %>%
+    filter(!(is_scenario(.data$metric) & (.data$year == start_year)))
   out
 }
 


### PR DESCRIPTION
Closes #513 

In this PR I add a filter to techmix prep function so that it filters out the scenario bar for start year. I did not keep the option to display the scenario bar in the current year as it does not make much sense to look at scenario in the start year as it is always equal to the portfolio. 