### PR TITLE
Add issues and PRs to GH projects

### DIFF
--- a/.github/workflows/add-prs-and-issues-to-project.yml
+++ b/.github/workflows/add-prs-and-issues-to-project.yml
@@ -1,0 +1,30 @@
+name: Add new issues and PRs to GH Projects
+
+on:
+  issues:
+    types:
+      - opened
+      - transferred
+  pull_request:
+    branches: [main]
+    types:
+      - opened
+
+jobs:
+  add-to-r2dii-proj:
+    name: Add issue/ PR to r2dii suite GH project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/RMI-PACTA/projects/11
+          github-token: ${{ secrets.PAT_ADD_ISSUES_TO_PROJECT }}
+    
+  add-to-maintainer-proj:
+    name: Add issue/ PR to @jdhoffa's maintenance GH project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/RMI-PACTA/projects/12
+          github-token: ${{ secrets.PAT_ADD_ISSUES_TO_PROJECT }}


### PR DESCRIPTION
I use two personal GH projects as an easy dashboard to view all open issues and PRs. 
I have two projects, one for the r2dii suite, and one for all of the repositories I maintain. 
This PR adds a workflow to add issues and PRs to each of them automatically. 

At this stage, I prefer not to share the project since I think it may be a sub-optimal solution.
I think in the future, we may want to do something more like this:
https://github.com/RMI-PACTA/Actions/issues/17

So this PR is just a band-aid for me until the above is closed (hopefully next sprint). 

Let me know if you have any questions :-) 

See also https://github.com/RMI-PACTA/r2dii.match/pull/441