### PR TITLE
Add more specific input checks for `plot_emission_intensity` and `prep_emission_intensity`

### DIFF
--- a/R/plot_emission_intensity.R
+++ b/R/plot_emission_intensity.R
@@ -39,10 +39,10 @@ plot_emission_intensity <- function(data) {
 }
 
 check_plot_emission_intensity <- function(data, env) {
+  check_prep_emission_intensity(data, env)
   crucial <- c(prep_emission_factor_crucial, "label")
   hint_if_missing_names(abort_if_missing_names(data, crucial), "sda")
-  check_prep_emission_intensity(data, env)
-  stopifnot(is.data.frame(data))
   abort_if_too_many_lines(data, max = 7)
+
   invisible(data)
 }

--- a/R/plot_emission_intensity.R
+++ b/R/plot_emission_intensity.R
@@ -39,6 +39,8 @@ plot_emission_intensity <- function(data) {
 }
 
 check_plot_emission_intensity <- function(data, env) {
+  crucial <- c(prep_emission_factor_crucial, "label")
+  hint_if_missing_names(abort_if_missing_names(data, crucial), "sda")
   check_prep_emission_intensity(data, env)
   stopifnot(is.data.frame(data))
   abort_if_too_many_lines(data, max = 7)

--- a/R/prep_emission_intensity.R
+++ b/R/prep_emission_intensity.R
@@ -49,7 +49,7 @@ prep_emission_intensity <- function(data,
 
 check_prep_emission_intensity <- function(data, env) {
   stopifnot(is.data.frame(data))
-  crucial <- c("sector", "year", glue("emission_factor_{c('metric', 'value')}"))
+  crucial <- prep_emission_factor_crucial
   hint_if_missing_names(abort_if_missing_names(data, crucial), "sda")
   enforce_single_value <- "sector"
   abort_if_multiple(data, enforce_single_value)
@@ -57,3 +57,9 @@ check_prep_emission_intensity <- function(data, env) {
 
   invisible(data)
 }
+
+prep_emission_factor_crucial <- c(
+  "sector",
+  "year",
+  glue("emission_factor_{c('metric', 'value')}")
+)

--- a/tests/testthat/_snaps/plot_emission_intensity.md
+++ b/tests/testthat/_snaps/plot_emission_intensity.md
@@ -11,15 +11,6 @@
     ! `data` must have all the expected names.
     x Missing names: emission_factor_metric, emission_factor_value, label.
 
-# if `data` has zero rows errors gracefully
-
-    `data` must have all the expected names.
-    x Missing names: label.
-    i Is your data `sda`-like?
-    Caused by error in `abort_if_missing_names()`:
-    ! `data` must have all the expected names.
-    x Missing names: label.
-
 # with too many sectors errors gracefully
 
     `data` must have all the expected names.

--- a/tests/testthat/_snaps/plot_emission_intensity.md
+++ b/tests/testthat/_snaps/plot_emission_intensity.md
@@ -1,26 +1,33 @@
 # if `data` is not a data frame errors gracefully
 
-    is.data.frame(data) is not TRUE
+    rlang::is_named(data) is not TRUE
 
 # if `data` is not sda-like errors gracefully
 
     `data` must have all the expected names.
-    x Missing names: emission_factor_metric, emission_factor_value.
+    x Missing names: emission_factor_metric, emission_factor_value, label.
     i Is your data `sda`-like?
     Caused by error in `abort_if_missing_names()`:
     ! `data` must have all the expected names.
-    x Missing names: emission_factor_metric, emission_factor_value.
+    x Missing names: emission_factor_metric, emission_factor_value, label.
 
 # if `data` has zero rows errors gracefully
 
-    `zero_row` must have some rows.
-    x `zero_row` has zero rows.
+    `data` must have all the expected names.
+    x Missing names: label.
+    i Is your data `sda`-like?
+    Caused by error in `abort_if_missing_names()`:
+    ! `data` must have all the expected names.
+    x Missing names: label.
 
 # with too many sectors errors gracefully
 
-    `data` must have a single value of `sector`.
-    i Do you need to pick one value? E.g. pick 'a' with: `subset(data, sector == 'a')`.
-    x Provided: a, b.
+    `data` must have all the expected names.
+    x Missing names: label.
+    i Is your data `sda`-like?
+    Caused by error in `abort_if_missing_names()`:
+    ! `data` must have all the expected names.
+    x Missing names: label.
 
 # with too many lines to plot errors gracefully
 

--- a/tests/testthat/_snaps/plot_emission_intensity.md
+++ b/tests/testthat/_snaps/plot_emission_intensity.md
@@ -1,15 +1,15 @@
 # if `data` is not a data frame errors gracefully
 
-    rlang::is_named(data) is not TRUE
+    is.data.frame(data) is not TRUE
 
 # if `data` is not sda-like errors gracefully
 
     `data` must have all the expected names.
-    x Missing names: emission_factor_metric, emission_factor_value, label.
+    x Missing names: emission_factor_metric, emission_factor_value.
     i Is your data `sda`-like?
     Caused by error in `abort_if_missing_names()`:
     ! `data` must have all the expected names.
-    x Missing names: emission_factor_metric, emission_factor_value, label.
+    x Missing names: emission_factor_metric, emission_factor_value.
 
 # if `data` has zero rows errors gracefully
 
@@ -18,12 +18,9 @@
 
 # with too many sectors errors gracefully
 
-    `data` must have all the expected names.
-    x Missing names: label.
-    i Is your data `sda`-like?
-    Caused by error in `abort_if_missing_names()`:
-    ! `data` must have all the expected names.
-    x Missing names: label.
+    `data` must have a single value of `sector`.
+    i Do you need to pick one value? E.g. pick 'a' with: `subset(data, sector == 'a')`.
+    x Provided: a, b.
 
 # with too many lines to plot errors gracefully
 

--- a/tests/testthat/_snaps/plot_emission_intensity.md
+++ b/tests/testthat/_snaps/plot_emission_intensity.md
@@ -11,6 +11,11 @@
     ! `data` must have all the expected names.
     x Missing names: emission_factor_metric, emission_factor_value, label.
 
+# if `data` has zero rows errors gracefully
+
+    `zero_row` must have some rows.
+    x `zero_row` has zero rows.
+
 # with too many sectors errors gracefully
 
     `data` must have all the expected names.

--- a/tests/testthat/_snaps/prep_emission_intensity.md
+++ b/tests/testthat/_snaps/prep_emission_intensity.md
@@ -1,0 +1,5 @@
+# if `data` has zero rows errors gracefully
+
+    `zero_row` must have some rows.
+    x `zero_row` has zero rows.
+

--- a/tests/testthat/test-plot_emission_intensity.R
+++ b/tests/testthat/test-plot_emission_intensity.R
@@ -9,11 +9,6 @@ test_that("if `data` is not sda-like errors gracefully", {
   expect_snapshot_error(plot_emission_intensity(bad))
 })
 
-test_that("if `data` has zero rows errors gracefully", {
-  zero_row <- sda[0L, ]
-  expect_snapshot_error(plot_emission_intensity(zero_row))
-})
-
 test_that("with too many sectors errors gracefully", {
   data <- head(sda, 2)
   data$sector <- c("a", "b")

--- a/tests/testthat/test-plot_emission_intensity.R
+++ b/tests/testthat/test-plot_emission_intensity.R
@@ -9,6 +9,11 @@ test_that("if `data` is not sda-like errors gracefully", {
   expect_snapshot_error(plot_emission_intensity(bad))
 })
 
+test_that("if `data` has zero rows errors gracefully", {
+  zero_row <- prep_emission_intensity(sda)[0L, ]
+  expect_snapshot_error(plot_emission_intensity(zero_row))
+})
+
 test_that("with too many sectors errors gracefully", {
   data <- head(sda, 2)
   data$sector <- c("a", "b")

--- a/tests/testthat/test-plot_emission_intensity.R
+++ b/tests/testthat/test-plot_emission_intensity.R
@@ -21,7 +21,9 @@ test_that("with too many sectors errors gracefully", {
 })
 
 test_that("outputs an object with no factor-columns derived from `specs`", {
-  data <- head(filter(sda, sector == "cement"))
+  data <- prep_emission_intensity(
+    head(filter(sda, sector == "cement"))
+  )
 
   p <- plot_emission_intensity(data)
   p_data <- p$layers[[1]]$data

--- a/tests/testthat/test-prep_emission_intensity.R
+++ b/tests/testthat/test-prep_emission_intensity.R
@@ -15,6 +15,11 @@ test_that("handles span_5yr correctly", {
   expect_true(all(as.integer(format(result$year, "%Y")) <= min(test_data$year) + 5))
 })
 
+test_that("if `data` has zero rows errors gracefully", {
+  zero_row <- sda[0L, ]
+  expect_snapshot_error(prep_emission_intensity(zero_row))
+})
+
 # Test handling of convert_label for factor and non-factor labels
 test_that("handles convert_label correctly", {
   # Mock convert_label function for testing

--- a/tests/testthat/test-scale_colour_r2dii.R
+++ b/tests/testthat/test-scale_colour_r2dii.R
@@ -67,6 +67,8 @@ test_that("with data having specific level factors, scales colours as expected
       )
     )
 
+  data <- prep_emission_intensity(data)
+
   p <- suppressWarnings(
     plot_emission_intensity(data),
     classes = "lifecycle_warning_deprecated"


### PR DESCRIPTION
The crucial difference between the input to `prep_emission_intensity` and the input to `plot_emission_intensity` (that I can see) is that the latter has the additional `label` column.

There is an "optional" difference, dependent on the value of `span_5yr`, but I don't think it makes sense to check for that since `plot_*` can't know a-priori what the argument passed to `prep_*` was.

The rest of the checks (that the input data is a data-frame etc.) are shared between the two functions.

Note: I wonder, perhaps we should add an exclusion test that the column `label` is NOT in the input to `prep_emission_intenstiy()`. @MonikaFu let me know if you have thoughts there.

Note: Adding the check brought a few bugs in the unit tests to light! woo 👯

Maybe closes #546 
Relates to #548 