### PR TITLE
remove `forcats` dep

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,6 @@ Depends:
     R (>= 3.4)
 Imports: 
     dplyr,
-    forcats,
     ggplot2,
     ggrepel,
     glue,


### PR DESCRIPTION
I believe I removed the only function that uses that dependency here: https://github.com/RMI-PACTA/r2dii.plot/pull/528

But I failed to remove the dependency itself from the `DESCRIPTION` file.

Closes #547 