### PR TITLE
don't use `scale_name` with {ggplot2} v3.5.0+

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: r2dii.plot
 Title: Visualize the Climate Scenario Alignment of a Financial Portfolio
-Version: 0.4.0.9009
+Version: 0.4.0.9010
 Authors@R: 
     c(person(given = "Monika",
              family = "Furdyna",

--- a/R/scale_colour_r2dii.R
+++ b/R/scale_colour_r2dii.R
@@ -24,13 +24,39 @@
 #'   geom_histogram(aes(cyl, fill = class), position = "dodge", bins = 5) +
 #'   scale_fill_r2dii()
 scale_colour_r2dii <- function(colour_labels = NULL, ...) {
-  discrete_scale("colour", "r2dii", r2dii_pal(colour_labels), ...)
+  if (utils::packageVersion("ggplot2") >= numeric_version("3.5.0")) {
+    discrete_scale(
+      aesthetics = "colour",
+      palette = r2dii_pal(colour_labels),
+      ...
+    )
+  } else {
+    discrete_scale(
+      aesthetics = "colour",
+      scale_name = "r2dii",
+      palette = r2dii_pal(colour_labels),
+      ...
+    )
+  }
 }
 
 #' @rdname scale_colour_r2dii
 #' @export
 scale_fill_r2dii <- function(colour_labels = NULL, ...) {
-  discrete_scale("fill", "r2dii", r2dii_pal(colour_labels), ...)
+  if (utils::packageVersion("ggplot2") >= numeric_version("3.5.0")) {
+    discrete_scale(
+      aesthetics = "fill",
+      palette = r2dii_pal(colour_labels),
+      ...
+    )
+  } else {
+    discrete_scale(
+      aesthetics = "fill",
+      scale_name = "r2dii",
+      palette = r2dii_pal(colour_labels),
+      ...
+    )
+  }
 }
 
 r2dii_pal <- function(colour_labels = NULL) {

--- a/R/scale_colour_r2dii_sector.R
+++ b/R/scale_colour_r2dii_sector.R
@@ -25,13 +25,39 @@
 #'   geom_histogram(aes(cyl, fill = class), position = "dodge", bins = 5) +
 #'   scale_fill_r2dii_sector()
 scale_colour_r2dii_sector <- function(sectors = NULL, ...) {
-  discrete_scale("colour", "r2dii_sector", r2dii_sec_pal(sectors), ...)
+  if (utils::packageVersion("ggplot2") >= numeric_version("3.5.0")) {
+    discrete_scale(
+      aesthetics = "colour",
+      palette = r2dii_sec_pal(sectors),
+      ...
+    )
+  } else {
+    discrete_scale(
+      aesthetics = "colour",
+      scale_name = "r2dii_sector",
+      palette = r2dii_sec_pal(sectors),
+      ...
+    )
+  }
 }
 
 #' @rdname scale_colour_r2dii_sector
 #' @export
 scale_fill_r2dii_sector <- function(sectors = NULL, ...) {
-  discrete_scale("fill", "r2dii_sector", r2dii_sec_pal(sectors), ...)
+  if (utils::packageVersion("ggplot2") >= numeric_version("3.5.0")) {
+    discrete_scale(
+      aesthetics = "fill",
+      palette = r2dii_sec_pal(sectors),
+      ...
+    )
+  } else {
+    discrete_scale(
+      aesthetics = "fill",
+      scale_name = "r2dii_sector",
+      palette = r2dii_sec_pal(sectors),
+      ...
+    )
+  }
 }
 
 r2dii_sec_pal <- function(sectors = NULL) {

--- a/R/scale_colour_r2dii_tech.R
+++ b/R/scale_colour_r2dii_tech.R
@@ -29,13 +29,39 @@
 #'   geom_histogram(aes(cyl, fill = class), position = "dodge", bins = 5) +
 #'   scale_fill_r2dii_tech("automotive")
 scale_colour_r2dii_tech <- function(sector, technologies = NULL, ...) {
-  discrete_scale("colour", "r2dii_tech", r2dii_tech_pal(sector, technologies), ...)
+  if (utils::packageVersion("ggplot2") >= numeric_version("3.5.0")) {
+    discrete_scale(
+      aesthetics = "colour",
+      palette = r2dii_tech_pal(sector, technologies),
+      ...
+    )
+  } else {
+    discrete_scale(
+      aesthetics = "colour",
+      scale_name = "r2dii_tech",
+      palette = r2dii_tech_pal(sector, technologies),
+      ...
+    )
+  }
 }
 
 #' @rdname scale_colour_r2dii_tech
 #' @export
 scale_fill_r2dii_tech <- function(sector, technologies = NULL, ...) {
-  discrete_scale("fill", "r2dii_tech", r2dii_tech_pal(sector, technologies), ...)
+  if (utils::packageVersion("ggplot2") >= numeric_version("3.5.0")) {
+    discrete_scale(
+      aesthetics = "fill",
+      palette = r2dii_tech_pal(sector, technologies),
+      ...
+    )
+  } else {
+    discrete_scale(
+      aesthetics = "fill",
+      scale_name = "r2dii_tech",
+      palette = r2dii_tech_pal(sector, technologies),
+      ...
+    )
+  }
 }
 
 r2dii_tech_pal <- function(sector, technologies = NULL) {


### PR DESCRIPTION
- resolves #577 

`scale_name` is [deprecated as of {ggplot2} v3.5.0](https://ggplot2.tidyverse.org/news/index.html#breaking-changes-3-5-0)

used the same strategy as [here](https://github.com/nanxstats/ggsci/pull/26) and [here](https://github.com/nanxstats/ggsci/pull/30) to adapt but remain backward compatible with {ggplot2} < v3.5.0

⚠️ note: @MonikaFu I didn't see the original deprecation warning mentioned in #577, but I now see messages in the tests about a colour scale being replaced 🤷🏻 
> Scale for colour is already present.
> Adding another scale for colour, which will replace the existing scale.