### PR TITLE
set values for doc template in `prep_trajectory()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: r2dii.plot
 Title: Visualize the Climate Scenario Alignment of a Financial Portfolio
-Version: 0.5.0.9000
+Version: 0.5.0.9001
 Authors@R: 
     c(person(given = "Monika",
              family = "Furdyna",

--- a/R/prep_trajectory.R
+++ b/R/prep_trajectory.R
@@ -6,6 +6,8 @@
 #' `region`, `scenario_source`.
 #' * (Optional) If present, the column `label` is used for data labels.
 #' @template convert_label
+#' @templateVar fun qplot_trajectory
+#' @templateVar value recode_metric_trajectory
 #' @param span_5yr Logical. Use `TRUE` to restrict the time span to 5 years from
 #'   the start year (the default behavior of `qplot_trajectory()`), or use
 #'   `FALSE` to impose no restriction.

--- a/man/prep_trajectory.Rd
+++ b/man/prep_trajectory.Rd
@@ -24,7 +24,8 @@ prep_trajectory(
 y-axis labels. For example:
 \itemize{
 \item To convert labels to uppercase use \code{convert_label = toupper}.
-\item To get the default behavior of `
+\item To get the default behavior of \code{qplot_trajectory()} use
+\code{convert_label = recode_metric_trajectory}.
 }}
 
 \item{span_5yr}{Logical. Use \code{TRUE} to restrict the time span to 5 years from


### PR DESCRIPTION
- resolves #594
- also fixes this section in the documentation https://rmi-pacta.github.io/r2dii.plot/reference/prep_trajectory.html#arg-convert-label

using
https://github.com/RMI-PACTA/r2dii.plot/blob/31331f32690c7765b140c0554eb8446945c8f26c/R/prep_trajectory.R#L8

requires setting `fun` and `value` because of the parameters used here
https://github.com/RMI-PACTA/r2dii.plot/blob/31331f32690c7765b140c0554eb8446945c8f26c/man-roxygen/convert_label.R#L1-L5

⚠️ note that using `@template` and `@templateVars` appears to be [superseded and no longer recommended](https://roxygen2.r-lib.org/articles/reuse.html#superseded)